### PR TITLE
Reduce CI time by only running against ubuntu-latest

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        os: [ubuntu-latest]
+        python-version: ["3.11"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -54,8 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        os: [ubuntu-latest]
+        python-version: ["3.11"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
# Summary

Since GitHub calculates a whole minute for running action jobs, even if those only run for a few seconds, the billable time for this project is way to high. For this reason, we now reduce the CI complexity by running actions only on ubuntu-latest against Python 3.11
