### PR TITLE
Resolve "Think of ignored executions during bot initialization"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.9.2
     hooks:
       - id: ruff
         args:
@@ -13,7 +13,7 @@ repos:
           - --fix
           - --exit-non-zero-on-fix
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
       - id: mypy
         name: mypy
@@ -27,7 +27,7 @@ repos:
           - --non-interactive
           - src
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.23.1
     hooks:
       - id: gitleaks
   - repo: https://github.com/codespell-project/codespell
@@ -72,7 +72,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.3.3
+    rev: v3.4.2
     hooks:
       - id: prettier
   - repo: https://github.com/PyCQA/isort # TODO: remove as soon as ruff is stable

--- a/src/kraken_infinity_grid/database.py
+++ b/src/kraken_infinity_grid/database.py
@@ -191,26 +191,25 @@ class Orderbook:
         if not filters:
             filters = {}
 
-        _updates = {} | filters
-        _updates.pop("userref", None)
+        prepared_updates = {}
         if "txid" in updates:
-            _updates["txid"] = updates["txid"]
+            prepared_updates["txid"] = updates["txid"]
 
         if descr := updates.get("descr"):
             if descr.get("pair"):
-                _updates["symbol"] = descr["pair"]
+                prepared_updates["symbol"] = descr["pair"]
             if descr.get("type"):
-                _updates["side"] = descr["type"]  # should not happen
+                prepared_updates["side"] = descr["type"]  # should not happen
             if descr.get("price"):
-                _updates["price"] = descr["price"]
+                prepared_updates["price"] = descr["price"]
 
         if "vol" in updates:
-            _updates["volume"] = updates["vol"]
+            prepared_updates["volume"] = updates["vol"]
 
         self.__db.update_row(
             self.__table,
             filters=filters | {"userref": self.__userref},
-            updates=_updates,
+            updates=prepared_updates,
         )
 
     def count(

--- a/src/kraken_infinity_grid/gridbot.py
+++ b/src/kraken_infinity_grid/gridbot.py
@@ -174,7 +174,7 @@ class KrakenInfinityGridBot(SpotWSClient):
         # If the algorithm receives execution messages before being ready to
         # trade, they will be stored here and processed later.
         ##
-        self.missed_messages: list[dict] = []
+        self.__missed_messages: list[dict] = []
 
         # Wait for ticker to be connected before do some action
         ##
@@ -268,15 +268,15 @@ class KrakenInfinityGridBot(SpotWSClient):
                 self.sm.prepare_for_trading()
 
                 # If there are any missed messages, process them now.
-                for msg in self.missed_messages:
+                for msg in self.__missed_messages:
                     await self.on_message(msg)
-                self.missed_messages = []
+                self.__missed_messages = []
 
             if not self.is_ready_to_trade:
                 if channel == "executions":
                     # If the algorithm is not ready to trade, store the
                     # executions to process them later.
-                    self.missed_messages.append(message)
+                    self.__missed_messages.append(message)
 
                 # Return here, until the algorithm is ready to trade. It is
                 # ready when the init/setup is done and the orderbook is

--- a/src/kraken_infinity_grid/gridbot.py
+++ b/src/kraken_infinity_grid/gridbot.py
@@ -171,6 +171,11 @@ class KrakenInfinityGridBot(SpotWSClient):
         self.xquote_currency: str | None = None  # ZEUR
         self.cost_decimals: int | None = None  # 5 for EUR, i.e., 0.00001 EUR
 
+        # If the algorithm receives execution messages before being ready to
+        # trade, they will be stored here and processed later.
+        ##
+        self.missed_messages: list[dict] = []
+
         # Wait for ticker to be connected before do some action
         ##
         self.__ticker_channel_connected: bool = False
@@ -261,9 +266,18 @@ class KrakenInfinityGridBot(SpotWSClient):
             ):
                 # Sets self.is_ready_to_trade to True
                 self.sm.prepare_for_trading()
-                return
+
+                # If there are any missed messages, process them now.
+                for msg in self.missed_messages:
+                    await self.on_message(msg)
+                self.missed_messages = []
 
             if not self.is_ready_to_trade:
+                if channel == "executions":
+                    # If the algorithm is not ready to trade, store the
+                    # executions to process them later.
+                    self.missed_messages.append(message)
+
                 # Return here, until the algorithm is ready to trade. It is
                 # ready when the init/setup is done and the orderbook is
                 # updated.


### PR DESCRIPTION
# Summary

In order to address the very rare situations, in which executions get ignored during the initial setup, we now save the executions that may happen before the algorithm is ready to trade. 

These saved messages will be executed right after the setup. Additionally, we don't return after the setup within the `on_message` function in order to address potential missing executions here as well.

Closes #16 