### PR TITLE
Resolve "Executed orders while the algorithm is down, create a death loop"

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,8 +412,14 @@ current state of the algorithm via Telegram Bots (see
   calculation is based on timestamps and a sent nonce must always be the highest
   nonce ever sent of that API key. Having multiple algorithms using the same
   keys will result in invalid nonce errors.
-- Always keep an eye on https://status.kraken.com/ when encountering
-  connectivity problems.
+- Kraken often has **maintenance windows**. Please check the status page at
+  https://status.kraken.com/ for more information.
+- When encountering errors like "Could not find order '...'. Retry 3/3 ...",
+  this might be due to the **Kraken API being slow**. The algorithm will retry
+  the request up to three times before raising an exception. If the order is
+  still not available, just restart the algorithm - or let this be handled by
+  Docker compose to restart the container automatically. Then the order will
+  most probably be found.
 
 ---
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -65,8 +65,14 @@ Troubleshooting
   calculation is based on timestamps and a sent nonce must always be the highest
   nonce ever sent of that API key. Having multiple algorithms using the same
   keys will result in invalid nonce errors.
-- Always keep an eye on https://status.kraken.com/ when encountering
-  connectivity problems.
+- Kraken often has **maintenance windows**. Please check the status page at
+  https://status.kraken.com/ for more information.
+- When encountering errors like "Could not find order '...'. Retry 3/3 ...",
+  this might be due to the **Kraken API being slow**. The algorithm will retry
+  the request up to three times before raising an exception. If the order is
+  still not available, just restart the algorithm - or let this be handled by
+  Docker compose to restart the container automatically. Then the order will
+  most probably be found.
 - Feel free to open an issue at `kraken-infinity-grid/issues`_.
 
 References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,10 @@ markers = [
   "wip: used for wip tests.",
 ]
 asyncio_default_fixture_loop_scope = "function"
+filterwarnings = [
+  "ignore:The .*async_close.* function is deprecated:DeprecationWarning:",
+  "ignore:The .*stop.* function is deprecated:DeprecationWarning:",
+]
 
 [tool.coverage.run]
 source = ["."]

--- a/tests/test_order_management.py
+++ b/tests/test_order_management.py
@@ -1073,7 +1073,7 @@ def test_get_orders_info_with_retry_success(
     """Test successfully retrieving order info with retry."""
     strategy.user.get_orders_info.return_value = {"txid1": {"status": "closed"}}
     result = order_manager.get_orders_info_with_retry(txid="txid1")
-    assert result == {"status": "closed"}
+    assert result == {"status": "closed", "txid": "txid1"}
     strategy.user.get_orders_info.assert_called_once_with(txid="txid1")
     mock_sleep.assert_not_called()
 
@@ -1090,7 +1090,7 @@ def test_get_orders_info_with_retry_retry_success(
         {"txid1": {"status": "closed"}},
     ]
     result = order_manager.get_orders_info_with_retry(txid="txid1")
-    assert result == {"status": "closed"}
+    assert result == {"status": "closed", "txid": "txid1"}
     assert strategy.user.get_orders_info.call_count == 2
     mock_sleep.assert_called_once()
 


### PR DESCRIPTION
In order to ensure the existence of the txid when accessing fetched orders, the key-value pair is simply added to the return value of `get_orders_info_with_retry`.

Closes #78 