### PR TITLE
Resolve "Websocket API faster than REST backend causing orders not being resolved"

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all:
+        dependency-type: "production"

--- a/src/kraken_infinity_grid/order_management.py
+++ b/src/kraken_infinity_grid/order_management.py
@@ -621,10 +621,14 @@ class OrderManager:
             tries += 1
 
         if order_details["status"] != "closed":
-            self.__s.save_exit(
-                "handle_filled_order_event - fetched order is not closed!"
-                f" {order_details}",
+            LOG.warning(
+                "Can not handle filled order, since the fetched order is not"
+                " closed in upstream!"
+                " This may happen due to Kraken's websocket API being faster"
+                " than their REST backend. Retrying in a few seconds...",
             )
+            self.handle_filled_order_event(txid=txid)
+            return
 
         # ======================================================================
         if self.__s.dry_run:

--- a/src/kraken_infinity_grid/order_management.py
+++ b/src/kraken_infinity_grid/order_management.py
@@ -834,6 +834,6 @@ class OrderManager:
                 f"Failed to retrieve order info for '{txid}' after"
                 f" {max_tries} retries!",
             )
-        order_details["txid"] = txid
 
+        order_details["txid"] = txid
         return order_details  # type: ignore[no-any-return]

--- a/src/kraken_infinity_grid/telegram.py
+++ b/src/kraken_infinity_grid/telegram.py
@@ -104,13 +104,14 @@ class Telegram:
 
         message += "\n```\n"
         message += f" 🏷️ Price in {self.__s.quote_currency}\n"
+        max_orders_to_list: int = 5
 
         next_sells = [
             order["price"]
             for order in self.__s.orderbook.get_orders(
                 filters={"side": "sell"},
                 order_by=("price", "ASC"),
-                limit=5,
+                limit=max_orders_to_list,
             )
         ]
         next_sells.reverse()
@@ -122,7 +123,7 @@ class Telegram:
                 change = (sell_price / self.__s.ticker.last - 1) * 100
                 if index == 0:
                     message += f" │  ┌[ {sell_price} (+{change:.2f}%)\n"
-                elif index <= n_sells - 1 and index != 4:
+                elif index <= n_sells - 1 and index != max_orders_to_list:
                     message += f" │  ├[ {sell_price} (+{change:.2f}%)\n"
             message += f" └──┼> {self.__s.ticker.last}\n"
 
@@ -131,13 +132,13 @@ class Telegram:
             for order in self.__s.orderbook.get_orders(
                 filters={"side": "buy"},
                 order_by=("price", "DESC"),
-                limit=5,
+                limit=max_orders_to_list,
             )
         ]
         if (n_buys := len(next_buys)) != 0:
             for index, buy_price in enumerate(next_buys):
                 change = (buy_price / self.__s.ticker.last - 1) * 100
-                if index < n_buys - 1 and index != 4:
+                if index < n_buys - 1 and index != max_orders_to_list:
                     message += f"    ├[ {buy_price} ({change:.2f}%)\n"
                 else:
                     message += f"    └[ {buy_price} ({change:.2f}%)"


### PR DESCRIPTION
# Summary

In order to avoid the situation stated in the issue, we're ensuring that the algorithm doesn't terminate if an order wasn't closed (via REST) but communicated as filled via websocket stream. 

We're retrying this until the order could be retrieved.

Testing done.

Closes #82 