### PR TITLE
Resolve "API key permission checks fail during dummy order placement for most assets

### DIFF
--- a/src/kraken_infinity_grid/gridbot.py
+++ b/src/kraken_infinity_grid/gridbot.py
@@ -488,11 +488,11 @@ class KrakenInfinityGridBot(SpotWSClient):
 
         LOG.info(" - Checking if 'Create & modify orders' permission set...")
         self.trade.create_order(
-            pair=self.symbol,
+            pair="BTC/USD",
             side="buy",
             ordertype="market",
-            volume="0.0001",
-            price="1",
+            volume="10",
+            price="10",
             validate=True,
         )
         LOG.info(" - Checking if 'Cancel & close orders' permission set...")


### PR DESCRIPTION
The source of the error was related to the trade permission check, which tried to place an order in "verify"/dummy mode to check if the permission is set.

This peace of code was adjusted to use the BTC/USD asset with a fixed volume and price to avoid future failures.

Closes #95 