### PR TITLE
Resolve "Add skip price check timeout flag"

### DIFF
--- a/src/kraken_infinity_grid/cli.py
+++ b/src/kraken_infinity_grid/cli.py
@@ -249,6 +249,16 @@ def cli(ctx: Context, **kwargs: dict) -> None:
     """,
 )
 @option(
+    "--skip-price-check",
+    is_flag=True,
+    default=False,
+    help="""
+    Skip checking if there was a price update in the last 10 minutes. By default,
+    the bot will exit if no recent price data is available. This might be useful
+    for assets that aren't traded that often.
+    """,
+)
+@option(
     "--sqlite-file",
     type=STRING,
     help="SQLite file to use as database.",

--- a/src/kraken_infinity_grid/gridbot.py
+++ b/src/kraken_infinity_grid/gridbot.py
@@ -168,6 +168,7 @@ class KrakenInfinityGridBot(SpotWSClient):
         self.strategy: str = config["strategy"]
         self.userref: int = config["userref"]
         self.name: str = config["name"]
+        self.skip_price_check = config.get("skip_price_check", False)
 
         # Commonly used config values
         ##
@@ -474,9 +475,11 @@ class KrakenInfinityGridBot(SpotWSClient):
                     # Send update once per hour to Telegram
                     self.t.send_telegram_update()
 
-                if conf["last_price_time"] + timedelta(seconds=600) < now:
-                    # Exit if no price update for a long time (10 minutes).
-                    LOG.error("No price update for a long time, exiting!")
+                if (
+                    not self.skip_price_check
+                    and conf["last_price_time"] + timedelta(seconds=600) < now
+                ):
+                    LOG.error("No price update within the last 10 minutes - exiting!")
                     self.state_machine.transition_to(States.ERROR)
                     return
 


### PR DESCRIPTION
Adding a new flag that disables the price timeout check. Some currency pairs like AVAX/EUR have timeframes of very low trading activity, resulting in the algorithm to restart which is unnecessary. 

Over the time developing this trading algorithm, I never encountered a serious event where this price check was even necessary or helpful, so having a new flag that disables this could be a good one. 

Not taking too much care of testing or good code, since this project is going to be reworked in https://github.com/btschwertfeger/kraken-infinity-grid/pull/109.

Closes #122 